### PR TITLE
Enabling using kv cache objects

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -46,13 +46,14 @@ def parse_args(args=None):
     return parser.parse_args(args)
 
 def scorer_e(dataset, predictions, answers, lengths, all_classes):
-    scores = {"0-4k": [], "4-8k": [], "8k+": []}
+    scores = {"0-4k": [], "4-8k": [], "8k+": [], "avg.": []}
     for (prediction, ground_truths, length) in zip(predictions, answers, lengths):
         score = 0.
         if dataset in ["trec", "triviaqa", "samsum", "lsht"]:
             prediction = prediction.lstrip('\n').split('\n')[0]
         for ground_truth in ground_truths:
             score = max(score, dataset2metric[dataset](prediction, ground_truth, all_classes=all_classes))
+        scores["avg."].append(score)
         if length < 4000:
             scores["0-4k"].append(score)
         elif length < 8000:

--- a/pred.py
+++ b/pred.py
@@ -2,7 +2,7 @@ import os
 from datasets import load_dataset
 import torch
 import json
-from transformers import AutoTokenizer, LlamaTokenizer, LlamaForCausalLM, AutoModelForCausalLM
+from transformers import AutoConfig, AutoTokenizer, LlamaTokenizer, LlamaForCausalLM, AutoModelForCausalLM
 from tqdm import tqdm
 import numpy as np
 import random
@@ -10,90 +10,103 @@ import argparse
 from llama_flash_attn_monkey_patch import replace_llama_attn_with_flash_attn
 import torch.distributed as dist
 import torch.multiprocessing as mp
+from transformers import (DynamicCache,
+                          SinkCache,
+                          SlidingWindowCache,
+                          QuantoQuantizedCache,
+                          )
+import gc
+from vllm import LLM, SamplingParams
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('--model', type=str, default=None, choices=["llama2-7b-chat-4k", "longchat-v1.5-7b-32k", "xgen-7b-8k", "internlm-7b-8k", "chatglm2-6b", "chatglm2-6b-32k", "chatglm3-6b-32k", "vicuna-v1.5-7b-16k", "llama3.1-8b-instruct", "baselineWithCuratedFTLongMSL8K", "baselineWithCuratedFTLongMSL8KCQ"])
+    parser.add_argument('--model', type=str, default=None,)
+    parser.add_argument('--max_seq_len', type=int, default=7500,)
     parser.add_argument('--e', action='store_true', help="Evaluate on LongBench-E")
+    parser.add_argument('--kv_method', type=str, default='full',)
+    parser.add_argument('--prefill_kv', action='store_true', help="prefill kv cache before generate function")
+    parser.add_argument('--backend', type=str, default='hf',choices=["hf","vllm"])
+    parser.add_argument('--load_in_8bit', action='store_true')
     return parser.parse_args(args)
 
-# This is the customized building prompt for chat models
-def build_chat(tokenizer, prompt, model_name):
-    if "chatglm3" in model_name:
-        prompt = tokenizer.build_chat_input(prompt)
-    elif "chatglm" in model_name:
-        prompt = tokenizer.build_prompt(prompt)
-    elif "longchat" in model_name or "vicuna" in model_name:
-        from fastchat.model import get_conversation_template
-        conv = get_conversation_template("vicuna")
-        conv.append_message(conv.roles[0], prompt)
-        conv.append_message(conv.roles[1], None)
-        prompt = conv.get_prompt()
-    elif "llama2" in model_name:
-        prompt = f"[INST]{prompt}[/INST]"
-    elif "xgen" in model_name:
-        header = (
-            "A chat between a curious human and an artificial intelligence assistant. "
-            "The assistant gives helpful, detailed, and polite answers to the human's questions.\n\n"
-        )
-        prompt = header + f" ### Human: {prompt}\n###"
-    elif "internlm" in model_name:
-        prompt = f"<|User|>:{prompt}<eoh>\n<|Bot|>:"
-    return prompt
+def prefill_kv_cache(past_key_values,model,input,max_gen_len):
+    input_ids = input['input_ids']
+    for idx in range(input_ids.shape[1]-1):
+        with torch.no_grad():
+            outputs = model(
+                input_ids[:, idx : idx + 1].to(device),
+                past_key_values=past_key_values,
+                use_cache=True,
+            )
+            past_key_values = outputs.past_key_values
+    return past_key_values
 
-def post_process(response, model_name):
-    if "xgen" in model_name:
-        response = response.strip().replace("Assistant:", "")
-    elif "internlm" in model_name:
-        response = response.split("<eoa>")[0]
-    return response
-
-def get_pred(rank, world_size, data, max_length, max_gen, prompt_format, dataset, device, model_name, model2path, out_path):
-    device = torch.device(f'cuda:{rank}')
-    model, tokenizer = load_model_and_tokenizer(model2path[model_name], model_name, device)
+def get_pred(data, max_length, max_gen, prompt_format, dataset, device, model, tokenizer, model_config, out_path, args=None):
+    # device = torch.device(f'cuda:{rank}')
     for json_obj in tqdm(data):
         prompt = prompt_format.format(**json_obj)
         # truncate to fit max_length (we suggest truncate in the middle, since the left and right side may contain crucial instructions)
         tokenized_prompt = tokenizer(prompt, truncation=False, return_tensors="pt").input_ids[0]
-        if "chatglm3" in model_name:
-            tokenized_prompt = tokenizer(prompt, truncation=False, return_tensors="pt", add_special_tokens=False).input_ids[0]
+
         if len(tokenized_prompt) > max_length:
             half = int(max_length/2)
             prompt = tokenizer.decode(tokenized_prompt[:half], skip_special_tokens=True)+tokenizer.decode(tokenized_prompt[-half:], skip_special_tokens=True)
-        if dataset not in ["trec", "triviaqa", "samsum", "lsht", "lcc", "repobench-p"]: # chat models are better off without build prompts on these tasks
-            prompt = build_chat(tokenizer, prompt, model_name)
-        if "chatglm3" in model_name:
-            if dataset in ["trec", "triviaqa", "samsum", "lsht", "lcc", "repobench-p"]:
-                input = tokenizer(prompt, truncation=False, return_tensors="pt").to(device)
-            else:
-                input = prompt.to(device)
-        else:
-            input = tokenizer(prompt, truncation=False, return_tensors="pt").to(device)
+        
+        input = tokenizer(prompt, truncation=False, return_tensors="pt").to(device)
         context_length = input.input_ids.shape[-1]
-        if dataset == "samsum": # prevent illegal output on samsum (model endlessly repeat "\nDialogue"), might be a prompting issue
-            output = model.generate(
-                **input,
-                max_new_tokens=max_gen,
-                num_beams=1,
-                do_sample=False,
-                temperature=1.0,
-                min_length=context_length+1,
-                eos_token_id=[tokenizer.eos_token_id, tokenizer.encode("\n", add_special_tokens=False)[-1]],
-            )[0]
+        if args.kv_method == 'full':
+            cache = DynamicCache()
+        elif args.kv_method == 'sink':
+            cache = SinkCache(window_length=2048, num_sink_tokens=8)
+        elif args.kv_method == 'sliding':
+            setattr(model_config, 'sliding_window', 2048)
+            cache = SlidingWindowCache(config=model_config,
+                                       max_batch_size=1,
+                                       max_cache_len=2048,
+                                       device='cuda')
+        if args.prefill_kv:
+            cache = prefill_kv_cache(cache,model,input,max_gen)
+        if args.backend == "hf":#dataset == "samsum": # prevent illegal output on samsum (model endlessly repeat "\nDialogue"), might be a prompting issue
+            with torch.no_grad():
+                output = model.generate(
+                    **input,
+                    max_new_tokens=max_gen,
+                    num_beams=1,
+                    do_sample=False,
+                    temperature=1.0,
+                    min_length=context_length+1,
+                    eos_token_id=[tokenizer.eos_token_id, tokenizer.encode("\n", add_special_tokens=False)[-1]],
+                    pad_token_id = tokenizer.eos_token_id,
+                    past_key_values=cache,
+                    # return_dict_in_generate=True,
+                )[0]
         else:
-            output = model.generate(
-                **input,
-                max_new_tokens=max_gen,
-                num_beams=1,
-                do_sample=False,
-                temperature=1.0,
-            )[0]
-        pred = tokenizer.decode(output[context_length:], skip_special_tokens=True)
-        pred = post_process(pred, model_name)
+            with torch.no_grad():
+                output = model.generate(
+                    prompt,
+                    SamplingParams(
+                        temperature=1.0,
+                        max_tokens=max_gen,
+                    )
+                    # max_new_tokens=max_gen,
+                    # num_beams=1,
+                    # do_sample=False,
+                    # temperature=1.0,
+                    # pad_token_id = tokenizer.eos_token_id,
+                    # past_key_values=cache,
+                    # return_dict_in_generate=True,
+                )
+        if args.backend == "hf":
+            pred = tokenizer.decode(output[context_length:], skip_special_tokens=True)
+            # print(output[0].outputs[0].text)
+        else:
+            pred = output[0].outputs[0].text
         with open(out_path, "a", encoding="utf-8") as f:
             json.dump({"pred": pred, "answers": json_obj["answers"], "all_classes": json_obj["all_classes"], "length": json_obj["length"]}, f, ensure_ascii=False)
             f.write('\n')
-    dist.destroy_process_group()
+        del input, output, pred
+        gc.collect()
+        torch.cuda.empty_cache()
 
 def seed_everything(seed):
     torch.manual_seed(seed)
@@ -104,48 +117,32 @@ def seed_everything(seed):
     torch.backends.cudnn.deterministic = True
     torch.cuda.manual_seed_all(seed)
 
-def load_model_and_tokenizer(path, model_name, device):
-    if "chatglm" in model_name or "internlm" in model_name or "xgen" in model_name:
-        tokenizer = AutoTokenizer.from_pretrained(path, trust_remote_code=True)
-        model = AutoModelForCausalLM.from_pretrained(path, trust_remote_code=True, torch_dtype=torch.bfloat16).to(device)
-    elif "llama2" in model_name:
-        replace_llama_attn_with_flash_attn()
-        tokenizer = LlamaTokenizer.from_pretrained(path)
-        model = LlamaForCausalLM.from_pretrained(path, torch_dtype=torch.bfloat16).to(device)
-    elif "llama3" in model_name or "baseline" in model_name:
-        tokenizer = AutoTokenizer.from_pretrained(path)
-        model = AutoModelForCausalLM.from_pretrained(path, torch_dtype=torch.bfloat16).to(device)
-    elif "longchat" in model_name or "vicuna" in model_name:
-        from fastchat.model import load_model
-        replace_llama_attn_with_flash_attn()
-        model, _ = load_model(
-            path,
-            device='cpu',
-            num_gpus=0,
-            load_8bit=False,
-            cpu_offloading=False,
-            debug=False,
-        )
-        model = model.to(device)
-        model = model.bfloat16()
-        tokenizer = AutoTokenizer.from_pretrained(path, trust_remote_code=True, use_fast=False)
-    model = model.eval()
-    return model, tokenizer
+def load_model_and_tokenizer(path,load_in_8bit,backend):
+    model_config = AutoConfig.from_pretrained(path)
+    tokenizer = AutoTokenizer.from_pretrained(path)
+    if backend == "vllm":
+        model = LLM(path)
+    elif backend == "hf":
+        if load_in_8bit:
+            model = AutoModelForCausalLM.from_pretrained(path, load_in_8bit=True,device_map='auto',attn_implementation='flash_attention_2')
+        else:
+            model = AutoModelForCausalLM.from_pretrained(path, torch_dtype=torch.bfloat16,device_map='auto',attn_implementation='flash_attention_2')#.to(device)
+            model = model.eval()
+    return model, tokenizer, model_config
 
 if __name__ == '__main__':
     seed_everything(42)
     args = parse_args()
-    world_size = torch.cuda.device_count()
-    mp.set_start_method('spawn', force=True)
 
     model2path = json.load(open("config/model2path.json", "r"))
     model2maxlen = json.load(open("config/model2maxlen.json", "r"))
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     model_name = args.model
-    # define your model
-    max_length = model2maxlen[model_name]
+    device='cuda' if torch.cuda.is_available() else 'cpu'
+    model, tokenizer, model_config = load_model_and_tokenizer(model_name, args.load_in_8bit,args.backend)
+    max_length = args.max_seq_len
     if args.e:
-        datasets = ["qasper", "multifieldqa_en", "hotpotqa", "2wikimqa", "gov_report", "multi_news", \
+        datasets = ["qasper", "multifieldqa_en", "hotpotqa", "2wikimqa", "gov_report", "multi_news",\
             "trec", "triviaqa", "samsum", "passage_count", "passage_retrieval_en", "lcc", "repobench-p"]
     else:
         datasets = ["narrativeqa", "qasper", "multifieldqa_en", "multifieldqa_zh", "hotpotqa", "2wikimqa", "musique", \
@@ -159,26 +156,29 @@ if __name__ == '__main__':
         os.makedirs("pred")
     if not os.path.exists("pred_e"):
         os.makedirs("pred_e")
+    output_dir_name = args.model.split('/')[-1]+ "_" + str(args.max_seq_len) + "_kv_cache_" + args.kv_method + "_backend_" + args.backend
+    if args.prefill_kv:
+        output_dir_name = output_dir_name + '_prefill_kv'
+    if args.load_in_8bit:
+        output_dir_name = output_dir_name + '_8bit'
     for dataset in datasets:
         if args.e:
             data = load_dataset('THUDM/LongBench', f"{dataset}_e", split='test')
-            if not os.path.exists(f"pred_e/{model_name}"):
-                os.makedirs(f"pred_e/{model_name}")
-            out_path = f"pred_e/{model_name}/{dataset}.jsonl"
+            if not os.path.exists(f"pred_e/{output_dir_name}"):
+                os.makedirs(f"pred_e/{output_dir_name}")
+            out_path = f"pred_e/{output_dir_name}/{dataset}.jsonl"
         else:
             data = load_dataset('THUDM/LongBench', dataset, split='test')
-            if not os.path.exists(f"pred/{model_name}"):
-                os.makedirs(f"pred/{model_name}")
-            out_path = f"pred/{model_name}/{dataset}.jsonl"
+            if not os.path.exists(f"pred/{output_dir_name}"):
+                os.makedirs(f"pred/{output_dir_name}")
+            out_path = f"pred/{output_dir_name}/{dataset}.jsonl"
+        if os.path.isfile(out_path) and os.access(out_path, os.R_OK):
+            print(f'Skipping {dataset}. Predictions already generated')
+            continue
+        print(f'Getting prediction on {dataset}.')
         prompt_format = dataset2prompt[dataset]
         max_gen = dataset2maxlen[dataset]
         data_all = [data_sample for data_sample in data]
-        data_subsets = [data_all[i::world_size] for i in range(world_size)]
         processes = []
-        for rank in range(world_size):
-            p = mp.Process(target=get_pred, args=(rank, world_size, data_subsets[rank], max_length, \
-                        max_gen, prompt_format, dataset, device, model_name, model2path, out_path))
-            p.start()
-            processes.append(p)
-        for p in processes:
-            p.join()
+        get_pred(data_all, max_length, max_gen, prompt_format, dataset, device, model, tokenizer, model_config, out_path, args)
+        

--- a/run_eval.sh
+++ b/run_eval.sh
@@ -1,0 +1,9 @@
+MODEL_PATH=/cb/cold/checkpoints/llms/HF/Meta-Llama-3-8B-Instruct #Phi-3-mini-128k-instruct
+IFS='/' read -r -a array <<< $MODEL_PATH
+MODEL_NAME=${array[-1]}
+DATASET=humaneval
+SEQ_LEN=7500
+KV_METHOD=full
+
+~/miniconda3/envs/longbench/bin/python pred.py --model $MODEL_PATH --e --max_seq_len $SEQ_LEN --kv_method $KV_METHOD --backend hf #--load_in_8bit
+# ~/miniconda3/envs/longbench/bin/python eval.py --model Meta-Llama-3-8B-Instruct_7500_kv_cache_full_backend_vllm --e #--max_seq_len 3500


### PR DESCRIPTION
added inference with kv cache
optimized to load the model once, not for every task.
added vllm backend for faster inference. vllm with kv cache objects is not supported yet.
modified the eval script to store an overall average for tasks too.
added a bash script for running the eval with different models and different sequence len. without the need for modifying scripts or configs.